### PR TITLE
Fix contract check count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note: This repo pins Clarinet SDK v3.5.0 via npm. Always use `npx clarinet`.
 git clone https://github.com/Anya-org/AutoVault.git
 cd AutoVault/stacks
 npm install
-npx clarinet check    # ✅ 65 contracts
+npx clarinet check    # ✅ 51 contracts
 npm test              # ✅ 130/131 tests
 ```
 


### PR DESCRIPTION
This pull request updates the documentation in the `README.md` file to reflect the current number of contracts being checked by Clarinet. The change is minor and only affects the displayed information about contract checks. 

* Updated the contract check result from "65 contracts" to "51 contracts" in the Clarinet usage example to accurately reflect the current state.