### PR TITLE
Fix Clarinet download URL to v3.5.0

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -66,7 +66,7 @@ jobs:
         run: npm ci --no-audit --no-fund
       - name: Install Clarinet
         run: |
-          curl -L https://github.com/hirosystems/clarinet/releases/download/v2.9.0/clarinet-linux-x64.tar.gz | tar xz
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64.tar.gz | tar xz
           sudo mv clarinet /usr/local/bin/clarinet
           chmod +x /usr/local/bin/clarinet
       - name: Verify Clarinet Installation
@@ -97,7 +97,7 @@ jobs:
         run: npm ci --no-audit --no-fund
       - name: Install Clarinet
         run: |
-          curl -L https://github.com/hirosystems/clarinet/releases/download/v2.9.0/clarinet-linux-x64.tar.gz | tar xz
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.5.0/clarinet-linux-x64.tar.gz | tar xz
           sudo mv clarinet /usr/local/bin/clarinet
           chmod +x /usr/local/bin/clarinet
       - name: Verify Clarinet Installation


### PR DESCRIPTION
## Problem
The deployment workflow fails with 404 error when downloading Clarinet v2.9.0 from GitHub releases.

## Root Cause
- Using outdated Clarinet version v2.9.0 (doesn't exist)
- Latest stable release is v3.5.0

## Solution
- Update download URL to use v3.5.0
- Fix both prepare and deploy job installations

## Impact
- Unblocks testnet deployment
- Enables contract compilation
- Critical for system validation