### PR TITLE
Add repo ownership boundary document

### DIFF
--- a/REPO_OWNERSHIP.md
+++ b/REPO_OWNERSHIP.md
@@ -1,0 +1,25 @@
+# Repo ownership
+
+## Purpose
+
+`Conxian` is treated as the protocol-first repository unless explicitly reclassified.
+
+## This repo owns
+
+- protocol identity
+- canonical protocol specifications and reference artifacts
+- contracts and protocol-adjacent materials where that is its active purpose
+
+## This repo does not own
+
+- canonical gateway runtime logic
+- wallet UX ownership
+- mixed adapter concerns that weaken protocol clarity
+
+## Boundary rule
+
+If a concern is primarily about integration runtime behavior, provider connectivity, or adapter implementation, it should live outside this repo.
+
+## Strategic role
+
+Role-sensitive repo, currently treated as protocol-first.


### PR DESCRIPTION
## What this adds

- `REPO_OWNERSHIP.md`

## Why

`Conxian` needs an explicit role statement while the portfolio is being aligned. The current working decision is to treat it as protocol-first unless reclassified.

## What it clarifies

- protocol-first ownership
- non-goals around gateway runtime and mixed adapter concerns

## Intended follow-up

- use this when narrowing the repo and deciding its long-term role