### PR TITLE
P0: distinguish protocol research from external proof

### DIFF
--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -6,50 +6,55 @@ permalink: /docs/RESEARCH/
 
 # Conxian Protocol Research & Strategic Analysis (2026 Update)
 
+## Reading guide
+
+This document is a strategic research surface.
+
+- It mixes market analysis, implementation interpretation, and forward-looking positioning.
+- Statements here should not be treated as audit results unless they are backed by separate audit artifacts.
+- Production-readiness claims should be tied to repository evidence, formal readiness gates, or independent verification.
+
 ## 1. Bitcoin L2 Landscape & Competitors (January 2026)
 
-- **Primary Platform (Stacks Nakamoto):** Now fully operational with Epoch 3.0. Conxian leverages `stacks-block-time` for second-level precision and inherits Bitcoin finality. The "Fast Blocks" (5s latency) allow Conxian's "Staff" agents to react to market volatility with unprecedented speed for a Bitcoin-native protocol.
+- **Primary Platform (Stacks Nakamoto):** Stacks Epoch 3.0 materially improves responsiveness and lets Conxian build against Bitcoin-anchored finality. Conxian uses this as part of its operating thesis, but end-to-end production claims still depend on implementation evidence and verification.
 - **Major Competitors:**
-  - **Rootstock (RSK):** Remains a player for EVM-compat, but lacks the native "Staff" automation model.
-  - **Merlin Chain & BOB:** Have gained significant TVL through EVM bridges, but face "Centralization of Sequencer" criticisms. Conxian's Nakamoto-native approach is seen as more "Sovereign."
-  - **Babylon:** Staking has matured; Conxian now explores integration for CXS-backed yield.
-- **Conxian Edge:** The **Sovereign Autonomous Business (SAB)** model. While others focus on *transactions*, Conxian focuses on *operations*. The "Staff" agent model (`agent-risk`, `agent-treasury`) provides a 24/7 operational moat that legacy sidechains cannot match without heavy human intervention.
+  - **Rootstock (RSK):** Remains a player for EVM-compat, but lacks Conxian's operations-first framing.
+  - **Merlin Chain & BOB:** Have gained significant TVL through EVM bridges, but face sequencer-centralization criticisms.
+  - **Babylon:** Staking has matured; Conxian continues to explore integration paths for yield-oriented flows.
+- **Conxian Edge:** The **Sovereign Autonomous Business (SAB)** model emphasizes operations and control surfaces, not only transactions. This is a strategic differentiator, but should be validated separately from repository-level implementation completeness.
 
 ## 2. Technical Research: Clarity 4 & Nakamoto Efficiency
 
-- **Clarity 4 Adoption:** The migration to Clarity 4 has introduced `secp256r1-verify`, enabling Conxian to support Passkey/Biometric signatures. This reduces the "UX Friction" for retail users.
-- **Contract-Hash Verification:** Using `contract-hash?` in the `conxian-protocol` registry ensures that only verified, un-tampered module code can be registered, mitigating "Upgrade-Proxy" risks common in EVM.
-- **Nakamoto Tenure Awareness:** Research into `block-utils` shows that being tenure-aware prevents "Fork-Grip" issues where agents might act on soon-to-be-reorganized blocks.
+- **Clarity 4 Adoption:** The migration to Clarity 4 introduces `secp256r1-verify`, which creates a plausible path for passkey and biometric-aligned UX patterns.
+- **Contract-Hash Verification:** Using `contract-hash?` in the `conxian-protocol` registry can reduce upgrade and tampering risk when used correctly.
+- **Nakamoto Tenure Awareness:** Research into `block-utils` suggests that tenure awareness can reduce issues around acting on unstable chain state.
 
 ## 3. Regulatory Landscape (MiCA, GDPR, SOC2)
 
-- **MiCA (Full Enforcement):**
-  - The EU has fully enforced MiCA. Conxian's `regulatory-adapter` ensures that all "Strategic Council" (Board) members are KYC-screened, providing "Clean-Hands" compliance.
-  - Asset-Referenced Tokens (ARTs): The protocol's transition to 1:1 asset-backed models (away from algorithmic) has secured its position in the European market.
-- **Travel Rule Compliance:** Implementation of the `travel-rule-service` using encrypted PII proofs allows institutional participants to meet FATF requirements without leaking sensitive data on-chain.
-- **SOC2 for DAOs:** Conxian is pioneering "Deterministic SOC2," where the protocol's autonomous agent logs serve as immutable audit trails for institutional compliance.
+- **MiCA:** Conxian's `regulatory-adapter` is part of the protocol's compliance posture, but legal and operational sufficiency should be validated independently from strategic documentation.
+- **Travel Rule Compliance:** Encrypted proof-oriented approaches may reduce on-chain data exposure, but institutional acceptability depends on implementation, jurisdiction, and auditability.
+- **SOC2 for DAOs:** Deterministic logging is a strong concept, but institutional compliance claims should remain evidence-backed and not inferred solely from architecture intent.
 
 ## 4. Financial Modeling & Performance (CAPEX/OPEX)
 
 - **CAPEX (Built):**
-  - **R&D:** 40+ modular contracts complete.
-  - **Security Audits:** Core primitives (DEX, Lending, Agents) have passed initial "Full Truth" audits.
+  - significant modular contract surface exists in the repository.
+  - security and verification claims should refer to formal audit artifacts where available.
 - **OPEX (Autonomous):**
-  - **Staff Payroll:** 20% revenue distribution to `operational-treasury` is maintaining the agent swarm (`keeper-coordinator`).
-  - **Yield Efficiency:** 60% revenue distribution to CXD stakers is outperforming traditional DeFi benchmarks due to the protocol's high-velocity XAAS model.
+  - treasury and revenue-routing logic can be reasoned about from code and docs, but operational performance claims require runtime evidence.
 
 ## 5. Residual Investment Risks (The "Brutally Honest" View)
 
-- **Infrastructure Lag:** While Nakamoto is fast, the underlying Bitcoin 10-minute finality still imposes a "Safety Delay" on high-value exits.
-- **Oracle Dependency:** Despite aggregation (Pyth/Redstone/Switchboard), a simultaneous failure or manipulation of multiple feeds remains a tail-risk.
-- **Regulatory Evolution:** Future "Level 2" MiCA technical standards may impose stricter requirements on "Autonomous Agent" legal personality.
-- **Governance Capture:** Large CXVG holders could theoretically collude during an AGM to shift the 60/20/20 split, although the `economic-policy-engine` has hard-coded immutability locks.
+- **Infrastructure Lag:** Bitcoin finality still creates safety-delay tradeoffs for high-value flows.
+- **Oracle Dependency:** Multi-oracle strategies reduce but do not remove correlated oracle risk.
+- **Regulatory Evolution:** Future rule changes may affect autonomous-agent operating assumptions.
+- **Governance Capture:** Token-based governance concentration remains a structural risk in any system with privileged governance rights.
 
 ## 6. Blue Ocean Opportunities (2026-2027)
 
-- **SAB-as-a-Service:** The "Conxian Corporate Engine" is being licensed to institutional sub-DAOs.
-- **Institutional "Clean-Hands" Lending:** Providing a walled-garden lending environment for TradFi capital.
-- **Cross-Chain "Staff" Orchestration:** Deploying agents to manage liquidity on Bitlayer and Citrea while settling back to Stacks/Bitcoin.
+- **SAB-as-a-Service:** The operating model may be licensable.
+- **Institutional "Clean-Hands" Lending:** Controlled compliance-focused lending remains a plausible segment.
+- **Cross-Chain "Staff" Orchestration:** Agent-managed cross-environment liquidity operations remain a strategic expansion path.
 
 ---
 © 2024-2026 Conxian Finance. All rights reserved.


### PR DESCRIPTION
## What changed
- tighten `docs/RESEARCH.md` so strategic research, implementation interpretation, and external proof are not conflated

## Why
This keeps protocol-facing research language useful without letting it read like an audit result or independent production certification.
